### PR TITLE
run_hls csim runs, cosim crashes with invalid memory issue

### DIFF
--- a/test/verilog_examples/halide_to_hardware/map_hls_files/run_hls.tcl
+++ b/test/verilog_examples/halide_to_hardware/map_hls_files/run_hls.tcl
@@ -1,7 +1,7 @@
 open_project -reset times_5
 set_top hls_target 
-#add_files -cflags -std=c++11 hls_target.cpp
-add_files hls_target.cpp
+add_files -cflags -std=c++11 hls_target.cpp
+#add_files hls_target.cpp
 #add_files hls_target.cpp
 
 #add_files -tb -cflags -std=c++11 test.cpp
@@ -9,7 +9,7 @@ add_files -tb test.cpp
 
 open_solution -reset "hls_target"
 
-csim_design
+csim_design -compiler clang
 
 set_part {xc7z020clg484-1}
 #set_part {xc7k160}
@@ -20,8 +20,9 @@ list_core
 create_clock -period 10
 csynth_design
 
+cosim_design -compiler clang -mflags "ExtraCXXFlags=-D_GLIBCXX_USE_CXX11_ABI=0" 
+
 export_design -rtl verilog
 
-cosim_design -rtl verilog
 
 exit


### PR DESCRIPTION
Gets farther, error now:
```
NFO: [COSIM 212-14] Instrumenting C test bench ...
   Build using "/cad/xilinx/vivado/2017.2/Vivado_HLS/2017.2/lnx64/tools/clang-3.9/bin/clang++"
   Compiling apatb_hls_target.cpp
   Compiling hls_target.cpp_pre.cpp.tb.cpp
   Compiling test.cpp_pre.cpp.tb.cpp
   Generating cosim.tv.exe
INFO: [COSIM 212-302] Starting C TB testing ...
ERROR: System recieved a signal named SIGSEGV and the program has to stop immediately!
This signal was generated when a program tries to read or write outside the memory that is allocated for it, or to write memory that can only be read.
Possible cause of this problem may be: 1) the depth setting of pointer type argument is much larger than it needed; 2)insufficient depth of array argument; 3)null pointer etc.
Current execution stopped during CodeState = DUMP_INPUTS.
You can search CodeState variable name in apatb*.cpp file under ./sim/wrapc dir to locate the position.
```